### PR TITLE
Octave Support for ISET3D-Tiny

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ ISET3d was originally developed in Brian Wandell's [Vistalab group](https://vist
 - The EXR readers come from OpenEXR and accept only the filename as input.
 - We still rely on `.mex` exr io functions but those are built using `mkoctfile`. See `isetcam/imgproc/openexr`
 - We have tested `isethdrsensor/scripts/fullSimulation.m` on examples from the ISET HDR dataset using Octave 6.4.0.
+- Refer to `isetcam/README.md` for Octave and Conda environment packages.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ To see some examples, have a look at the tutorial directory. If you want to read
 Note: This repository was formerly ISET3d-v4, pbrt2iset, and before that we relied on RenderToolbox4.
 
 ISET3d was originally developed in Brian Wandell's [Vistalab group](https://vistalab.stanford.edu/) at [Stanford University](stanford.edu), along with co-contributors from other research institutions and industry.
+
+## Octave Support
+- July 14, 2025: Ayush Jamdar at Omnivision Technologies Inc.
+- The EXR readers come from OpenEXR and accept only the filename as input.
+- We still rely on `.mex` exr io functions but those are built using `mkoctfile`. See `isetcam/imgproc/openexr`
+- We have tested `isethdrsensor/scripts/fullSimulation.m` on examples from the ISET HDR dataset.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note: This repository was formerly ISET3d-v4, pbrt2iset, and before that we reli
 ISET3d was originally developed in Brian Wandell's [Vistalab group](https://vistalab.stanford.edu/) at [Stanford University](stanford.edu), along with co-contributors from other research institutions and industry.
 
 ## Octave Support
-- July 14, 2025: Ayush Jamdar at Omnivision Technologies Inc.
+- July 14, 2025: Ayush Jamdar.
 - The EXR readers come from OpenEXR and accept only the filename as input.
 - We still rely on `.mex` exr io functions but those are built using `mkoctfile`. See `isetcam/imgproc/openexr`
-- We have tested `isethdrsensor/scripts/fullSimulation.m` on examples from the ISET HDR dataset.
+- We have tested `isethdrsensor/scripts/fullSimulation.m` on examples from the ISET HDR dataset using Octave 6.4.0.

--- a/utilities/pbrt/pbrt-v4/piEXR2ISET.m
+++ b/utilities/pbrt/pbrt-v4/piEXR2ISET.m
@@ -94,7 +94,7 @@ for ii = 1:numel(label)
                 nn = nn+1;
             end
             try
-                % New format
+                % New format: Perhaps they mean MATLAB's exrread()?
                 energy = exrread(inputFile,Channels = radianceChannels);
             catch
                 % keep the old format
@@ -109,13 +109,17 @@ for ii = 1:numel(label)
 
         case {'depth', 'zdepth'}
             info = exrinfo(inputFile);
-            channelNames = info.ChannelInfo.Properties.RowNames;
-            if contains('P.X',channelNames)
+            % disp(info);
+            % fieldnames(info)
+            channelNames = info.channels;
+            if any(strcmp('P.X', channelNames))
                 % Modern naming for X,Y,Z coordinates
-                coordinates = exrread(inputFile,Channels=["P.X","P.Y","P.Z"]);
-            elseif contains('Px',channelNames)
+                % coordinates = exrread(inputFile,Channels=["P.X","P.Y","P.Z"]);
+                coordinates = exrread(inputFile);
+            elseif any(strcmp('Px', channelNames))
                 % Historical naming
-                coordinates = exrread(inputFile,Channels=["Px","Py","Pz"]);
+                % coordinates = exrread(inputFile,Channels=["Px","Py","Pz"]);
+                coordinates = exrread(inputFile);
             else
                 warning('No X,Y,Z channels found.  Returning.');
                 return;

--- a/utilities/pbrt/pbrt-v4/piEXR2Mat.m
+++ b/utilities/pbrt/pbrt-v4/piEXR2Mat.m
@@ -61,7 +61,10 @@ if hasBuiltinExrread
     return;
 
 elseif isfile(fullfile(isetRootPath,'imgproc','openexr','exrreadchannels.mex'))
-    % Use the exrread() from ISETCam.
+    % If Matlab's exrread() isn't available, the user must be using 
+    % openexr's exrread() (either from older Matlab or Octave)
+    % In this case, the mex file should exist
+    % Note that this file reader uses arguments different from Matlab's
     
     if strcmpi(channelname,'radiance')
         channels = cell(1,31);

--- a/utilities/pbrt/pbrt-v4/piEXR2Mat.m
+++ b/utilities/pbrt/pbrt-v4/piEXR2Mat.m
@@ -18,8 +18,20 @@ function data = piEXR2Mat(inputFile, channelname)
 % dockerWrapper Support, D. Cardinal, 2022
 %
 
+% Below lines are added for Octave compatiblity
+% Should ideally support runs from both Octave and MATLAB
+
+% Determine if we're in Octave
+isOctave = exist('OCTAVE_VERSION', 'builtin') ~= 0;
+
+% Check if MATLAB exrread() is available
+hasBuiltinExrread = false;
+if ~isOctave && exist('isMATLABReleaseOlderThan', 'file') > 0
+    hasBuiltinExrread = ~isMATLABReleaseOlderThan('R2022b');
+end
+
 % tic
-if exist('isMATLABReleaseOlderThan','file') > 0 && ~isMATLABReleaseOlderThan('R2022b')
+if hasBuiltinExrread
     % Use Matlab builtin exrread from the image toolbox 
 
     % Matlab included exrread() in 2022b.  We included exread() in
@@ -48,8 +60,7 @@ if exist('isMATLABReleaseOlderThan','file') > 0 && ~isMATLABReleaseOlderThan('R2
     data = exrread(inputFile, Channels = channels);
     return;
 
-elseif isfile(fullfile(isetRootPath,'imgproc','openexr','exrread.m'))
-    
+elseif isfile(fullfile(isetRootPath,'imgproc','openexr','exrreadchannels.mex'))
     % Use the exrread() from ISETCam.
     
     if strcmpi(channelname,'radiance')
@@ -95,7 +106,7 @@ else
 
     if status
         disp(result);
-        error('EXR to Binary conversion failed.')
+        error('EXR to Binary conversion failed.');
     end
     allFiles = dir([indir,sprintf('/%s_*',fname)]);
     fileList = [];


### PR DESCRIPTION
While ISET is an amazing simulation tool, it depends on its user's having paid MATLAB licenses which might not be accessible to all individuals and organizations interested in using the toolbox.
 
GNU Octave is a free and open-source alternative for MATLAB. It imitates most MATLAB functionality with code and CLI but has different libraries, toolboxes, and datatypes.  One third-party package of importance in `isethdrsensor` is `openexr`. With help from Brian and David, I was able to modify the current ISET codebase to work with Octave 6.4.0.

The changes are briefly described at the end of `README.md` and the necessary packages are listed in another PR opened in the `isetcam`  repository. 

This PR goes along with the two others opened in `isetcam` and `isethdrsensor` repos. All these branches are named `dev-octave`.

I have tested this code on Octave 6.4.0 using a conda environment as detailed in `isetcam/environment.yml`.

Hope this helps extend access to ISET!